### PR TITLE
Update colors to 0.1.3 and change order once again

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://user-images.githubusercontent.com/58336662/147009539-b5604e70-6942-4ecd-
 
 ## Usage
 
-1. Copy the contets of [catppuccin.cava](https://github.com/catppuccin/cava/blob/main/catppuccin.cava) into your Cava config file (usually located at: `$HOME/.config/cava/`)
+1. Copy the contents of [catppuccin.cava](https://github.com/catppuccin/cava/blob/main/catppuccin.cava) into your Cava config file (usually located at: `$HOME/.config/cava/`), replacing the existing gradient settings
 2. Reload cava if it was already playing
 
 ## 💝 Thanks to

--- a/catppuccin.cava
+++ b/catppuccin.cava
@@ -2,12 +2,11 @@
 
 gradient = 1
 
-gradient_color_1 = '#B7E5E6'
-gradient_color_2 = '#92D2E8'
-gradient_color_3 = '#A3B9EF'
-gradient_color_4 = '#C6AAE8'
-gradient_color_5 = '#E5B4E2'
-gradient_color_6 = '#E49CB3'
+gradient_color_1 = '#B5E8E0'
+gradient_color_2 = '#89DCEB'
+gradient_color_3 = '#96CDFB'
+gradient_color_4 = '#DDB6F2'
+gradient_color_5 = '#F5C2E7'
+gradient_color_6 = '#E8A2AF'
 gradient_color_7 = '#F2CDCD'
 gradient_color_8 = '#F5E0DC'
-

--- a/catppuccin.cava
+++ b/catppuccin.cava
@@ -2,12 +2,12 @@
 
 gradient = 1
 
-gradient_color_1 = '#BEE4ED'
-gradient_color_2 = '#A4B9EF'
-gradient_color_3 = '#C6AAE8'
-gradient_color_4 = '#E5B4E2'
-gradient_color_5 = '#F2CECF'
-gradient_color_6 = '#EBDDAA'
-gradient_color_7 = '#F9C096'
-gradient_color_8 = '#E38C8F'
+gradient_color_1 = '#B7E5E6'
+gradient_color_2 = '#92D2E8'
+gradient_color_3 = '#A3B9EF'
+gradient_color_4 = '#C6AAE8'
+gradient_color_5 = '#E5B4E2'
+gradient_color_6 = '#E49CB3'
+gradient_color_7 = '#F2CDCD'
+gradient_color_8 = '#F5E0DC'
 


### PR DESCRIPTION
Updates colors to Catppuccin 0.1.2 and changes the order again for a smoother and more pleasant look and transition.

![grim-2022-01-03-11-24-07](https://user-images.githubusercontent.com/20235646/147902874-df0a1c79-955f-444a-8925-9a913d63c766.png)
