### PR TITLE
feat: Add support for background colours

### DIFF
--- a/frappe.cava
+++ b/frappe.cava
@@ -1,5 +1,7 @@
 [color]
 
+background = '#303446'
+
 gradient = 1
 
 gradient_color_1 = '#81c8be'

--- a/latte.cava
+++ b/latte.cava
@@ -1,5 +1,7 @@
 [color]
 
+background = '#eff1f5'
+
 gradient = 1
 
 gradient_color_1 = '#179299'

--- a/macchiato.cava
+++ b/macchiato.cava
@@ -1,5 +1,7 @@
 [color]
 
+background = '#24273a'
+
 gradient = 1
 
 gradient_color_1 = '#8bd5ca'

--- a/mocha.cava
+++ b/mocha.cava
@@ -1,5 +1,7 @@
 [color]
 
+background = '#1e1e2e'
+
 gradient = 1
 
 gradient_color_1 = '#94e2d5'


### PR DESCRIPTION
Cava has a feature in it config to set the background of the visualiser. This improves things for users working with the SDL2 renderer as the window does not have a background colour set by the terminal.